### PR TITLE
update: Updated Kafka Retry AOP

### DIFF
--- a/core/src/main/java/com/f_lab/joyeuse_planete/core/kafka/aspect/KafkaRetryAspect.java
+++ b/core/src/main/java/com/f_lab/joyeuse_planete/core/kafka/aspect/KafkaRetryAspect.java
@@ -4,6 +4,7 @@ import com.f_lab.joyeuse_planete.core.exceptions.JoyeusePlaneteApplicationExcept
 import com.f_lab.joyeuse_planete.core.exceptions.ErrorCode;
 import com.f_lab.joyeuse_planete.core.util.log.LogUtil;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.common.KafkaException;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
@@ -26,7 +27,7 @@ public class KafkaRetryAspect {
     while (attempts < MAX_RETRY) {
       try {
         return joinPoint.proceed();
-      } catch (Throwable e) {
+      } catch (KafkaException e) {
         LogUtil.retry(++attempts, joinPoint.getSignature().toString());
 
         try {
@@ -35,9 +36,13 @@ public class KafkaRetryAspect {
           LogUtil.exception(joinPoint.getSignature().toString(), ex);
           throw new JoyeusePlaneteApplicationException(ErrorCode.KAFKA_RETRY_FAIL_EXCEPTION, ex);
         }
+      } catch (Throwable e) {
+        LogUtil.exception(joinPoint.getSignature().toString(), e);
+        throw new JoyeusePlaneteApplicationException(ErrorCode.KAFKA_RETRY_FAIL_EXCEPTION, e);
       }
     }
 
     throw new JoyeusePlaneteApplicationException(ErrorCode.KAFKA_RETRY_FAIL_EXCEPTION);
   }
+
 }

--- a/core/src/main/java/com/f_lab/joyeuse_planete/core/kafka/config/KafkaConsumerConfig.java
+++ b/core/src/main/java/com/f_lab/joyeuse_planete/core/kafka/config/KafkaConsumerConfig.java
@@ -55,7 +55,7 @@ public abstract class KafkaConsumerConfig {
       LogUtil.exception("KafkaConsumerConfig.defaultDeadLetterTopicStrategy", ex);
 
       record.headers().add(KafkaHeaders.EXCEPTION_FQCN, ex.getClass().getName().getBytes());
-      record.headers().add(KafkaHeaders.EXCEPTION_MESSAGE, ex.getMessage().getBytes());
+      record.headers().add(KafkaHeaders.EXCEPTION_MESSAGE, ((ex.getMessage() != null) ? ex.getMessage() : "null").getBytes());
       record.headers().add(KafkaHeaders.ORIGINAL_TOPIC, record.topic().getBytes());
 
       return new TopicPartition(deadLetterTopic, -1);


### PR DESCRIPTION
- kafka retry 로직을 조금 구체적으로 Throwable 에서 KafkaException에 retry 를 하도록 변경하였습니다.
- error message 가 null일 경우에 kafka 무한 루프에 걸리는 것을 확인하고 null일 때 강제적으로 null 메세지를 넣도록 하였습니다. 