### PR TITLE
chore: Added @Timed to services

### DIFF
--- a/foods/src/main/java/com/f_lab/joyeuse_planete/foods/config/MonitorConfig.java
+++ b/foods/src/main/java/com/f_lab/joyeuse_planete/foods/config/MonitorConfig.java
@@ -1,0 +1,16 @@
+package com.f_lab.joyeuse_planete.foods.config;
+
+import com.f_lab.joyeuse_planete.core.monitor.Monitor;
+import io.micrometer.core.aop.TimedAspect;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class MonitorConfig {
+
+  @Bean
+  public TimedAspect timedAspect(MeterRegistry registry) {
+    return new Monitor(registry).timedAspect();
+  }
+}

--- a/foods/src/main/java/com/f_lab/joyeuse_planete/foods/service/FoodService.java
+++ b/foods/src/main/java/com/f_lab/joyeuse_planete/foods/service/FoodService.java
@@ -8,6 +8,7 @@ import com.f_lab.joyeuse_planete.foods.dto.request.CreateFoodRequestDTO;
 import com.f_lab.joyeuse_planete.foods.dto.request.UpdateFoodRequestDTO;
 import com.f_lab.joyeuse_planete.foods.dto.response.FoodDTO;
 import com.f_lab.joyeuse_planete.foods.repository.FoodRepository;
+import io.micrometer.core.annotation.Timed;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -16,7 +17,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 
-@Slf4j
+@Timed("foods")
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)

--- a/orders/src/main/java/com/f_lab/joyeuse_planete/orders/config/MonitorConfig.java
+++ b/orders/src/main/java/com/f_lab/joyeuse_planete/orders/config/MonitorConfig.java
@@ -1,0 +1,16 @@
+package com.f_lab.joyeuse_planete.orders.config;
+
+import com.f_lab.joyeuse_planete.core.monitor.Monitor;
+import io.micrometer.core.aop.TimedAspect;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class MonitorConfig {
+
+  @Bean
+  public TimedAspect timedAspect(MeterRegistry registry) {
+    return new Monitor(registry).timedAspect();
+  }
+}

--- a/orders/src/main/java/com/f_lab/joyeuse_planete/orders/service/OrderService.java
+++ b/orders/src/main/java/com/f_lab/joyeuse_planete/orders/service/OrderService.java
@@ -13,8 +13,8 @@ import com.f_lab.joyeuse_planete.orders.dto.response.OrderDTO;
 import com.f_lab.joyeuse_planete.orders.dto.request.OrderCreateRequestDTO;
 import com.f_lab.joyeuse_planete.orders.dto.response.OrderCreateResponseDTO;
 import com.f_lab.joyeuse_planete.orders.repository.OrderRepository;
+import io.micrometer.core.annotation.Timed;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -22,7 +22,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 
-@Slf4j
+@Timed("orders")
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor

--- a/payment/src/main/java/com/f_lab/joyeuse_planete/payment/config/MonitorConfig.java
+++ b/payment/src/main/java/com/f_lab/joyeuse_planete/payment/config/MonitorConfig.java
@@ -1,0 +1,16 @@
+package com.f_lab.joyeuse_planete.payment.config;
+
+import com.f_lab.joyeuse_planete.core.monitor.Monitor;
+import io.micrometer.core.aop.TimedAspect;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class MonitorConfig {
+
+  @Bean
+  public TimedAspect timedAspect(MeterRegistry registry) {
+    return new Monitor(registry).timedAspect();
+  }
+}

--- a/payment/src/main/java/com/f_lab/joyeuse_planete/payment/service/PaymentService.java
+++ b/payment/src/main/java/com/f_lab/joyeuse_planete/payment/service/PaymentService.java
@@ -1,8 +1,10 @@
 package com.f_lab.joyeuse_planete.payment.service;
 
+import io.micrometer.core.annotation.Timed;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+@Timed("payment")
 @Service
 @RequiredArgsConstructor
 public class PaymentService {


### PR DESCRIPTION
- 각 프로젝트 마다 config 파일을 생성해서 @Timed annotation을 쓸 수 있도록 하였습니다. 
- 비즈니스 로직의 시간 및 호출 횟수를 측정하기 위해서 service layer에 @Timed annotation를 부착했습니다. 