### PR TITLE
update: Updated retry annotations

### DIFF
--- a/core/src/main/java/com/f_lab/joyeuse_planete/core/aspect/LockRetryAspect.java
+++ b/core/src/main/java/com/f_lab/joyeuse_planete/core/aspect/LockRetryAspect.java
@@ -27,7 +27,7 @@ public class LockRetryAspect {
       try {
         return joinPoint.proceed();
       } catch (PessimisticLockException | LockTimeoutException e) {
-        LogUtil.retry(++attempts, joinPoint.getSignature().toString());
+        LogUtil.retry(attempts, retry.value(), joinPoint.getSignature().toString());
 
         // 재시도 전 잠시 멈추고 다시 시작
         // 각 시도 마다 WAIT_INTERVAL 이 MULTIPLIER 에 상응하는 값을 지수적으로 늘어납니다 (backoff)

--- a/core/src/main/java/com/f_lab/joyeuse_planete/core/aspect/LockRetryAspect.java
+++ b/core/src/main/java/com/f_lab/joyeuse_planete/core/aspect/LockRetryAspect.java
@@ -10,24 +10,20 @@ import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @Aspect
 @Component
 public class LockRetryAspect {
-
-  @Value("${lock.max.retry:2}")
-  private int MAX_RETRY;
   private static final int FIRST_WAIT_INTERVAL = Integer.parseInt(TimeConstantsString.ONE_SECOND);
   private static final int MULTIPLIER = 2;
 
-  @Around("@annotation(com.f_lab.joyeuse_planete.core.aspect.RetryOnLockFailure)")
-  public Object lockRetry(ProceedingJoinPoint joinPoint) {
-    int attempts = 0, stopInterval = FIRST_WAIT_INTERVAL;
+  @Around("@annotation(retry)")
+  public Object lockRetry(ProceedingJoinPoint joinPoint, RetryOnLockFailure retry) {
+    int stopInterval = FIRST_WAIT_INTERVAL;
 
-    while (attempts < MAX_RETRY) {
+    for (int attempts = 0; attempts < retry.value(); attempts++) {
       try {
         return joinPoint.proceed();
       } catch (PessimisticLockException | LockTimeoutException e) {

--- a/core/src/main/java/com/f_lab/joyeuse_planete/core/aspect/RetryOnLockFailure.java
+++ b/core/src/main/java/com/f_lab/joyeuse_planete/core/aspect/RetryOnLockFailure.java
@@ -8,4 +8,5 @@ import java.lang.annotation.Target;
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface RetryOnLockFailure {
+  int value() default 3;
 }

--- a/core/src/main/java/com/f_lab/joyeuse_planete/core/kafka/aspect/KafkaRetry.java
+++ b/core/src/main/java/com/f_lab/joyeuse_planete/core/kafka/aspect/KafkaRetry.java
@@ -8,4 +8,5 @@ import java.lang.annotation.Target;
 @Target({ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface KafkaRetry {
+  int value() default 3;
 }

--- a/core/src/main/java/com/f_lab/joyeuse_planete/core/kafka/aspect/KafkaRetryAspect.java
+++ b/core/src/main/java/com/f_lab/joyeuse_planete/core/kafka/aspect/KafkaRetryAspect.java
@@ -10,12 +10,14 @@ import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.springframework.stereotype.Component;
 
+import static com.f_lab.joyeuse_planete.core.util.time.TimeConstantsString.ONE_SECOND;
+
 @Slf4j
 @Aspect
 @Component
 public class KafkaRetryAspect {
 
-  private static final int STOP_INTERVAL = 1000;
+  private static final int STOP_INTERVAL = Integer.parseInt(ONE_SECOND);
 
   @Around("@annotation(retry)")
   public Object kafkaRetry(ProceedingJoinPoint joinPoint, KafkaRetry retry) {

--- a/core/src/main/java/com/f_lab/joyeuse_planete/core/kafka/aspect/KafkaRetryAspect.java
+++ b/core/src/main/java/com/f_lab/joyeuse_planete/core/kafka/aspect/KafkaRetryAspect.java
@@ -26,7 +26,7 @@ public class KafkaRetryAspect {
       try {
         return joinPoint.proceed();
       } catch (KafkaException e) {
-        LogUtil.retry(++attempts, joinPoint.getSignature().toString());
+        LogUtil.retry(attempts, retry.value(), joinPoint.getSignature().toString());
 
         try {
           Thread.sleep(STOP_INTERVAL);

--- a/core/src/main/java/com/f_lab/joyeuse_planete/core/kafka/aspect/KafkaRetryAspect.java
+++ b/core/src/main/java/com/f_lab/joyeuse_planete/core/kafka/aspect/KafkaRetryAspect.java
@@ -8,7 +8,6 @@ import org.apache.kafka.common.KafkaException;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -16,15 +15,12 @@ import org.springframework.stereotype.Component;
 @Component
 public class KafkaRetryAspect {
 
-  @Value("${kafka.lock.max.retry:3}")
-  private int MAX_RETRY;
   private static final int STOP_INTERVAL = 1000;
 
-  @Around("@annotation(com.f_lab.joyeuse_planete.core.kafka.aspect.KafkaRetry)")
-  public Object kafkaRetry(ProceedingJoinPoint joinPoint) {
-    int attempts = 0;
+  @Around("@annotation(retry)")
+  public Object kafkaRetry(ProceedingJoinPoint joinPoint, KafkaRetry retry) {
 
-    while (attempts < MAX_RETRY) {
+    for (int attempts = 0; attempts < retry.value(); attempts++) {
       try {
         return joinPoint.proceed();
       } catch (KafkaException e) {
@@ -44,5 +40,4 @@ public class KafkaRetryAspect {
 
     throw new JoyeusePlaneteApplicationException(ErrorCode.KAFKA_RETRY_FAIL_EXCEPTION);
   }
-
 }

--- a/core/src/main/java/com/f_lab/joyeuse_planete/core/util/log/LogUtil.java
+++ b/core/src/main/java/com/f_lab/joyeuse_planete/core/util/log/LogUtil.java
@@ -8,8 +8,8 @@ public class LogUtil {
     log.error("오류가 발생하였습니다. method = {} message = {}", method, e.getMessage(), e);
   }
 
-  public static void retry(int attempts, String method) {
-    log.warn("시도 횟수={}, 다시 메서드={} 락을 얻기를 시도합니다", attempts, method);
+  public static void retry(int attempts, int maxAttemps, String method) {
+    log.warn("시도 횟수={}/{}, 다시 메서드={} 락을 얻기를 시도합니다", attempts, maxAttemps, method);
   }
 
   public static void deadLetterMissingFormats(String exceptionName, String exceptionMessage, String originalTopic) {


### PR DESCRIPTION
- retry annotation (e.g. DB, Kafka) 들을 업데이트하였습니다. 
- 기존의 max_attempt를 aop aspect 에서 정하는 것이 아닌 annotation을 직접적으로 사용하는 코드에서 유연하게 결정할 수 있게 하였습니다. 
- 또 kafka aop 에서 사용하던 1초를 기존의 시간 관련 상수들을 모아 놓는 클래스에서 import 하게 할 수 있게 하였습니다. 