### PR TITLE
refactor: Refactored jwt filter, cookie logics

### DIFF
--- a/core/src/main/java/com/f_lab/joyeuse_planete/core/config/DefaultAsyncConfig.java
+++ b/core/src/main/java/com/f_lab/joyeuse_planete/core/config/DefaultAsyncConfig.java
@@ -9,7 +9,7 @@ import java.util.concurrent.Executor;
 
 @EnableAsync
 @Configuration
-public class DefaultAsyncConfig {
+public abstract class DefaultAsyncConfig {
 
   private static final int CORE_POOL_SIZE = 20;
   private static final int MAX_POOL_SIZE = Integer.MAX_VALUE;
@@ -17,7 +17,7 @@ public class DefaultAsyncConfig {
   private static final String NAME_PREFIX = "ASYNC_THREAD_";
 
   @Bean(name = { "executor", "asyncExecutor" })
-  public Executor taskExecutor() {
+  protected Executor taskExecutor() {
     ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
 
     executor.setCorePoolSize(CORE_POOL_SIZE);

--- a/core/src/main/java/com/f_lab/joyeuse_planete/core/config/DefaultAsyncConfig.java
+++ b/core/src/main/java/com/f_lab/joyeuse_planete/core/config/DefaultAsyncConfig.java
@@ -6,11 +6,10 @@ import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
 
 @EnableAsync
 @Configuration
-public class AsyncConfig {
+public class DefaultAsyncConfig {
 
   private static final int CORE_POOL_SIZE = 20;
   private static final int MAX_POOL_SIZE = Integer.MAX_VALUE;

--- a/core/src/main/java/com/f_lab/joyeuse_planete/core/domain/OrderStatus.java
+++ b/core/src/main/java/com/f_lab/joyeuse_planete/core/domain/OrderStatus.java
@@ -19,7 +19,8 @@ public enum OrderStatus {
   EXPIRED("주문의 유효 시간 5분이 지나 거래가 취소된 상태입니다."),
   FAIL_FOOD_QUANTITY("요청한 상품의 수량이 부족하여 주문이 실패하였습니다."),
   FAIL_FOOD_INVALID_ID("요청한 상품이 존재하지 않아 주문이 실패하였습니다."),
-  FAIL("주문이 실패하였습니다.")
+  FAIL_ORDER("주문이 실패하였습니다."),
+  FAIL_CANCEL("주문이 실패하였습니다.")
   ;
 
   private final String description;

--- a/core/src/main/java/com/f_lab/joyeuse_planete/core/domain/OrderStatus.java
+++ b/core/src/main/java/com/f_lab/joyeuse_planete/core/domain/OrderStatus.java
@@ -20,7 +20,7 @@ public enum OrderStatus {
   FAIL_FOOD_QUANTITY("요청한 상품의 수량이 부족하여 주문이 실패하였습니다."),
   FAIL_FOOD_INVALID_ID("요청한 상품이 존재하지 않아 주문이 실패하였습니다."),
   FAIL_ORDER("주문이 실패하였습니다."),
-  FAIL_CANCEL("주문이 실패하였습니다.")
+  FAIL_CANCEL("주문취소가 원할히 진행되지 못했습니다.")
   ;
 
   private final String description;

--- a/core/src/main/java/com/f_lab/joyeuse_planete/core/events/EventToEventMapper.java
+++ b/core/src/main/java/com/f_lab/joyeuse_planete/core/events/EventToEventMapper.java
@@ -4,11 +4,19 @@ import com.f_lab.joyeuse_planete.core.exceptions.ErrorCode;
 
 public class EventToEventMapper {
 
-  public static FoodReservationFailedEvent mapToCompensationEvent(OrderCreatedEvent orderCreatedEvent, ErrorCode errorCode) {
-    return FoodReservationFailedEvent.toEvent(orderCreatedEvent, errorCode);
+  public static FoodReservationFailedEvent mapToCompensationEvent(OrderCreatedEvent event, ErrorCode errorCode) {
+    return FoodReservationFailedEvent.toEvent(event, errorCode);
   }
 
-  public static FoodReleaseFailedEvent mapToCompensationEvent(OrderCancelEvent orderCancelEvent, ErrorCode errorCode) {
-    return FoodReleaseFailedEvent.toEvent(orderCancelEvent, errorCode);
+  public static FoodReservationFailedEvent mapToCompensationEvent(FoodReservationProcessedEvent event, ErrorCode errorCode) {
+    return FoodReservationFailedEvent.toEvent(event, errorCode);
+  }
+
+  public static FoodReleaseFailedEvent mapToCompensationEvent(OrderCancelEvent event, ErrorCode errorCode) {
+    return FoodReleaseFailedEvent.toEvent(event, errorCode);
+  }
+
+  public static FoodReleaseFailedEvent mapToCompensationEvent(FoodReleaseEvent event, ErrorCode errorCode) {
+    return FoodReleaseFailedEvent.toEvent(event, errorCode);
   }
 }

--- a/core/src/main/java/com/f_lab/joyeuse_planete/core/events/FoodReleaseEvent.java
+++ b/core/src/main/java/com/f_lab/joyeuse_planete/core/events/FoodReleaseEvent.java
@@ -12,10 +12,12 @@ import lombok.NoArgsConstructor;
 public class FoodReleaseEvent {
 
   private Long paymentId;
+  private transient Long orderId;
 
   public static FoodReleaseEvent toEvent(OrderCancelEvent event) {
     return FoodReleaseEvent.builder()
         .paymentId(event.getPaymentId())
+        .orderId(event.getOrderId())
         .build();
   }
 }

--- a/core/src/main/java/com/f_lab/joyeuse_planete/core/events/FoodReleaseFailedEvent.java
+++ b/core/src/main/java/com/f_lab/joyeuse_planete/core/events/FoodReleaseFailedEvent.java
@@ -21,4 +21,11 @@ public class FoodReleaseFailedEvent {
         .errorCode(errorCode)
         .build();
   }
+
+  public static FoodReleaseFailedEvent toEvent(FoodReleaseEvent event, ErrorCode errorCode) {
+    return FoodReleaseFailedEvent.builder()
+        .orderId(event.getOrderId())
+        .errorCode(errorCode)
+        .build();
+  }
 }

--- a/core/src/main/java/com/f_lab/joyeuse_planete/core/events/FoodReservationFailedEvent.java
+++ b/core/src/main/java/com/f_lab/joyeuse_planete/core/events/FoodReservationFailedEvent.java
@@ -21,4 +21,11 @@ public class FoodReservationFailedEvent {
         .errorCode(errorCode)
         .build();
   }
+
+  public static FoodReservationFailedEvent toEvent(FoodReservationProcessedEvent event, ErrorCode errorCode) {
+    return FoodReservationFailedEvent.builder()
+        .orderId(event.getOrderId())
+        .errorCode(errorCode)
+        .build();
+  }
 }

--- a/core/src/main/java/com/f_lab/joyeuse_planete/core/events/FoodReservationProcessedEvent.java
+++ b/core/src/main/java/com/f_lab/joyeuse_planete/core/events/FoodReservationProcessedEvent.java
@@ -12,10 +12,14 @@ import lombok.NoArgsConstructor;
 public class FoodReservationProcessedEvent {
 
   private Long orderId;
+  private transient Long foodId;
+  private transient int quantity;
 
   public static FoodReservationProcessedEvent toEvent(OrderCreatedEvent event) {
     return FoodReservationProcessedEvent.builder()
         .orderId(event.getOrderId())
+        .foodId(event.getFoodId())
+        .quantity(event.getQuantity())
         .build();
   }
 }

--- a/core/src/main/java/com/f_lab/joyeuse_planete/core/exceptions/ErrorCode.java
+++ b/core/src/main/java/com/f_lab/joyeuse_planete/core/exceptions/ErrorCode.java
@@ -45,6 +45,9 @@ public enum ErrorCode {
   INVALID_PASSWORD("결제 비밀번호가 일치하지 않습니다.", 403),
   PAYMENT_UNKNOWN_EXCEPTION("알 수 없는 오류가 결제 중 발생하였습니다. 다시 시도해주세요.", 400),
 
+  // 환불 관련 오류
+  FOOD_RELEASE_KAFKA_FAIL_EVENT("환불이 실패하였습니다. 고객센터에 연락주시기를 바랍니다.", 500),
+
   // 기타 오류
   UNKNOWN_EXCEPTION("알 수 없는 오류가 발생하였습니다. 다시 시도해주세요.", 500),
 

--- a/core/src/main/java/com/f_lab/joyeuse_planete/core/exceptions/ErrorCodeOrderStatusTranslator.java
+++ b/core/src/main/java/com/f_lab/joyeuse_planete/core/exceptions/ErrorCodeOrderStatusTranslator.java
@@ -9,7 +9,8 @@ public class ErrorCodeOrderStatusTranslator {
   private static final Map<ErrorCode, OrderStatus> ERROR_CODE_MAP = Map.of(
       ErrorCode.FOOD_NOT_ENOUGH_STOCK, OrderStatus.FAIL_FOOD_QUANTITY,
       ErrorCode.FOOD_NOT_EXIST_EXCEPTION, OrderStatus.FAIL_ORDER,
-      ErrorCode.ORDER_NOT_EXIST_EXCEPTION, OrderStatus.FAIL_ORDER
+      ErrorCode.ORDER_NOT_EXIST_EXCEPTION, OrderStatus.FAIL_ORDER,
+      ErrorCode.FOOD_RELEASE_KAFKA_FAIL_EVENT, OrderStatus.FAIL_CANCEL
   );
 
   public static OrderStatus translate(ErrorCode errorCode) {

--- a/core/src/main/java/com/f_lab/joyeuse_planete/core/exceptions/ErrorCodeOrderStatusTranslator.java
+++ b/core/src/main/java/com/f_lab/joyeuse_planete/core/exceptions/ErrorCodeOrderStatusTranslator.java
@@ -8,11 +8,11 @@ public class ErrorCodeOrderStatusTranslator {
 
   private static final Map<ErrorCode, OrderStatus> ERROR_CODE_MAP = Map.of(
       ErrorCode.FOOD_NOT_ENOUGH_STOCK, OrderStatus.FAIL_FOOD_QUANTITY,
-      ErrorCode.FOOD_NOT_EXIST_EXCEPTION, OrderStatus.FAIL,
-      ErrorCode.ORDER_NOT_EXIST_EXCEPTION, OrderStatus.FAIL
+      ErrorCode.FOOD_NOT_EXIST_EXCEPTION, OrderStatus.FAIL_ORDER,
+      ErrorCode.ORDER_NOT_EXIST_EXCEPTION, OrderStatus.FAIL_ORDER
   );
 
   public static OrderStatus translate(ErrorCode errorCode) {
-    return ERROR_CODE_MAP.getOrDefault(errorCode, OrderStatus.FAIL);
+    return ERROR_CODE_MAP.getOrDefault(errorCode, OrderStatus.FAIL_ORDER);
   }
 }

--- a/core/src/main/java/com/f_lab/joyeuse_planete/core/security/config/DefaultSecurityConfig.java
+++ b/core/src/main/java/com/f_lab/joyeuse_planete/core/security/config/DefaultSecurityConfig.java
@@ -3,6 +3,7 @@ package com.f_lab.joyeuse_planete.core.security.config;
 
 import com.f_lab.joyeuse_planete.core.security.filter.JwtFilter;
 import jakarta.servlet.Filter;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
@@ -15,12 +16,22 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import static com.f_lab.joyeuse_planete.core.util.time.TimeConstants.TimeConstantLong.ONE_HOUR;
 
 
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity
 public abstract class DefaultSecurityConfig {
+
+
+  @Value("${cookie.domain:.localhost}")
+  private String DOMAIN;
+
 
   abstract protected Filter jwtFilter();
   abstract protected Filter jwtExceptionFilter();
@@ -32,7 +43,8 @@ public abstract class DefaultSecurityConfig {
 
         .csrf(AbstractHttpConfigurer::disable)
 
-        .cors(AbstractHttpConfigurer::disable)
+        .cors(cors -> cors
+            .configurationSource(corsConfigurationSource()))
 
         .formLogin(AbstractHttpConfigurer::disable)
 
@@ -45,6 +57,20 @@ public abstract class DefaultSecurityConfig {
         .addFilterBefore(jwtExceptionFilter(), JwtFilter.class)
 
         .build();
+  }
+
+  public CorsConfigurationSource corsConfigurationSource() {
+    CorsConfiguration corsConfiguration = new CorsConfiguration();
+
+    corsConfiguration.addAllowedOrigin(DOMAIN);
+    corsConfiguration.addAllowedHeader("*");
+    corsConfiguration.addAllowedMethod("*");
+    corsConfiguration.setMaxAge(ONE_HOUR);
+
+    UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+    source.registerCorsConfiguration("/**", corsConfiguration);
+
+    return source;
   }
 
   @Bean

--- a/core/src/main/java/com/f_lab/joyeuse_planete/core/security/config/DefaultSecurityConfig.java
+++ b/core/src/main/java/com/f_lab/joyeuse_planete/core/security/config/DefaultSecurityConfig.java
@@ -65,6 +65,7 @@ public abstract class DefaultSecurityConfig {
     corsConfiguration.addAllowedOrigin(DOMAIN);
     corsConfiguration.addAllowedHeader("*");
     corsConfiguration.addAllowedMethod("*");
+    corsConfiguration.setAllowCredentials(true);
     corsConfiguration.setMaxAge(ONE_HOUR);
 
     UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();

--- a/core/src/main/java/com/f_lab/joyeuse_planete/core/security/cookie/CookieUtil.java
+++ b/core/src/main/java/com/f_lab/joyeuse_planete/core/security/cookie/CookieUtil.java
@@ -11,7 +11,7 @@ import java.util.Arrays;
 
 public class CookieUtil {
 
-  @Value("${cookie.domain:localhost}")
+  @Value("${cookie.domain:.localhost}")
   private String DOMAIN;
 
   @Value("${cookie.path:/}")
@@ -36,13 +36,27 @@ public class CookieUtil {
     if (cookies == null)
       return null;
 
-    Cookie cookie = Arrays.stream(cookies)
+    return Arrays.stream(cookies)
         .filter(c -> c.getName().equals(REFRESH_TOKEN_KEY))
+        .map(Cookie::getValue)
         .findAny()
-        .orElseGet(() -> null);
+        .orElse(null);
+  }
 
-    return (cookie != null)
-        ? cookie.getValue()
-        : null;
+  public void deleteCookie(HttpServletRequest request, HttpServletResponse response) {
+    Cookie[] cookies = request.getCookies();
+
+    if (cookies != null) {
+      Arrays.stream(cookies)
+          .filter(c -> c.getName().equals(REFRESH_TOKEN_KEY))
+          .findFirst()
+          .ifPresent(c -> {
+            c.setDomain(DOMAIN);
+            c.setPath(PATH);
+            c.setMaxAge(0);
+
+            response.addCookie(c);
+          });
+    }
   }
 }

--- a/core/src/main/java/com/f_lab/joyeuse_planete/core/security/jwt/JwtUtil.java
+++ b/core/src/main/java/com/f_lab/joyeuse_planete/core/security/jwt/JwtUtil.java
@@ -46,8 +46,8 @@ public class JwtUtil {
     return encrypt(payload, JWT_EXPIRATION_DATE_REFRESH);
   }
 
-  public Long getMemberId(String token) {
-    return objectMapper.convertValue(decrypt(token).getPayload().get(JWT_PAYLOAD_IDENTITY_FIELD), Payload.class).getMemberId();
+  public Long getId(String token) {
+    return objectMapper.convertValue(decrypt(token).getPayload().get(JWT_PAYLOAD_IDENTITY_FIELD), Payload.class).getId();
   }
 
   public MemberRole getMemberRole(String token) {
@@ -103,14 +103,14 @@ public class JwtUtil {
   @AllArgsConstructor
   public static class Payload {
 
-    @JsonProperty("member_id")
-    private Long memberId;
+    @JsonProperty("id")
+    private Long id;
 
     @JsonProperty("role")
     private MemberRole role;
 
-    public static Payload generate(Long memberId, MemberRole role) {
-      return new Payload(memberId, role);
+    public static Payload generate(Long id, MemberRole role) {
+      return new Payload(id, role);
     }
   }
 }

--- a/core/src/main/java/com/f_lab/joyeuse_planete/core/util/log/LogUtil.java
+++ b/core/src/main/java/com/f_lab/joyeuse_planete/core/util/log/LogUtil.java
@@ -20,7 +20,7 @@ public class LogUtil {
     log.warn("DEAD LETTER TOPIC 에서 오류가 발생하였습니다. topic = {}, name = {}, message = {}", originalTopic, exceptionName, exceptionMessage);
   }
 
-  public static void info(String method, Object object) {
+  public static void errorInfo(String method, Object object) {
     log.error("오류가 발생하였습니다.  method = {} object = {}", method, object);
   }
 }

--- a/core/src/main/java/com/f_lab/joyeuse_planete/core/util/log/LogUtil.java
+++ b/core/src/main/java/com/f_lab/joyeuse_planete/core/util/log/LogUtil.java
@@ -19,4 +19,8 @@ public class LogUtil {
   public static void deadLetterSaveFail(String exceptionName, String exceptionMessage, String originalTopic) {
     log.warn("DEAD LETTER TOPIC 에서 오류가 발생하였습니다. topic = {}, name = {}, message = {}", originalTopic, exceptionName, exceptionMessage);
   }
+
+  public static void info(String method, Object object) {
+    log.error("오류가 발생하였습니다.  method = {} object = {}", method, object);
+  }
 }

--- a/core/src/main/java/com/f_lab/joyeuse_planete/core/util/time/TimeConstants.java
+++ b/core/src/main/java/com/f_lab/joyeuse_planete/core/util/time/TimeConstants.java
@@ -11,6 +11,10 @@ public class TimeConstants {
 
   }
 
+  public static class TimeConstantLong {
+    public static final long ONE_HOUR = 3600L;
+  }
+
   public static class TimeConstantsMillis {
     public static final int FIVE_SECONDS = 5000;
     public static final int ONE_SECOND = 1000;

--- a/core/src/test/java/com/f_lab/joyeuse_planete/core/util/jwt/JwtUtilTest.java
+++ b/core/src/test/java/com/f_lab/joyeuse_planete/core/util/jwt/JwtUtilTest.java
@@ -56,7 +56,7 @@ class JwtUtilTest {
 
     // when
     String accessToken = jwtUtil.generateAccessToken(payload);
-    Long extractedMemberId = jwtUtil.getMemberId(accessToken);
+    Long extractedMemberId = jwtUtil.getId(accessToken);
     boolean hasExpired = jwtUtil.hasExpired(accessToken);
 
     // then
@@ -74,7 +74,7 @@ class JwtUtilTest {
 
     // when
     String refreshToken = jwtUtil.generateRefreshToken(payload);
-    Long extractedMemberId = jwtUtil.getMemberId(refreshToken);
+    Long extractedMemberId = jwtUtil.getId(refreshToken);
     boolean hasExpired = jwtUtil.hasExpired(refreshToken);
 
     // then

--- a/foods/src/main/java/com/f_lab/joyeuse_planete/foods/config/AsyncConfig.java
+++ b/foods/src/main/java/com/f_lab/joyeuse_planete/foods/config/AsyncConfig.java
@@ -8,7 +8,7 @@ import org.springframework.context.annotation.Configuration;
 public class AsyncConfig {
 
   @Bean
-  public DefaultAsyncConfig asyncConfig() {
+  public DefaultAsyncConfig defaultAsyncConfig() {
     return new DefaultAsyncConfig();
   }
 }

--- a/foods/src/main/java/com/f_lab/joyeuse_planete/foods/config/AsyncConfig.java
+++ b/foods/src/main/java/com/f_lab/joyeuse_planete/foods/config/AsyncConfig.java
@@ -1,0 +1,14 @@
+package com.f_lab.joyeuse_planete.foods.config;
+
+import com.f_lab.joyeuse_planete.core.config.DefaultAsyncConfig;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AsyncConfig {
+
+  @Bean
+  public DefaultAsyncConfig asyncConfig() {
+    return new DefaultAsyncConfig();
+  }
+}

--- a/foods/src/main/java/com/f_lab/joyeuse_planete/foods/controller/FoodController.java
+++ b/foods/src/main/java/com/f_lab/joyeuse_planete/foods/controller/FoodController.java
@@ -14,6 +14,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -48,6 +49,7 @@ public class FoodController {
     return foodService.getFoodList(condition, pageable);
   }
 
+  @PreAuthorize("hasRole('STORE')")
   @PostMapping
   public ResponseEntity<ResultResponse> createFood(@RequestBody @Valid CreateFoodRequestDTO request) {
     foodService.createFood(request);
@@ -57,6 +59,7 @@ public class FoodController {
         .body(ResultResponse.of(CommonResponses.CREATE_SUCCESS, HttpStatus.CREATED.value()));
   }
 
+  @PreAuthorize("hasRole('STORE')")
   @PutMapping("/{foodId}")
   public ResponseEntity<ResultResponse> updateFood(@PathVariable Long foodId,
                                                    @RequestBody @Valid UpdateFoodRequestDTO request
@@ -69,6 +72,7 @@ public class FoodController {
         .body(ResultResponse.of(CommonResponses.UPDATE_SUCCESS, HttpStatus.OK.value()));
   }
 
+  @PreAuthorize("hasRole('STORE')")
   @DeleteMapping("/{foodId}")
   public ResponseEntity<ResultResponse> deleteFood(@PathVariable Long foodId) {
     foodService.deleteFood(foodId);

--- a/foods/src/main/java/com/f_lab/joyeuse_planete/foods/service/listener/FoodEventListener.java
+++ b/foods/src/main/java/com/f_lab/joyeuse_planete/foods/service/listener/FoodEventListener.java
@@ -1,12 +1,18 @@
 package com.f_lab.joyeuse_planete.foods.service.listener;
 
+import com.f_lab.joyeuse_planete.core.events.EventToEventMapper;
 import com.f_lab.joyeuse_planete.core.events.FoodReleaseEvent;
 import com.f_lab.joyeuse_planete.core.events.FoodReleaseFailedEvent;
 import com.f_lab.joyeuse_planete.core.events.FoodReservationFailedEvent;
 import com.f_lab.joyeuse_planete.core.events.FoodReservationProcessedEvent;
+import com.f_lab.joyeuse_planete.core.exceptions.ErrorCode;
 import com.f_lab.joyeuse_planete.core.kafka.service.KafkaService;
+import com.f_lab.joyeuse_planete.core.util.log.LogUtil;
+import com.f_lab.joyeuse_planete.foods.service.FoodService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionalEventListener;
 
@@ -18,6 +24,8 @@ import static org.springframework.transaction.event.TransactionPhase.AFTER_ROLLB
 public class FoodEventListener {
 
   private final KafkaService kafkaService;
+  private final FoodService foodService;
+  private final ApplicationEventPublisher eventPublisher;
 
   @Value("${foods.events.topics.reserve}")
   private String FOOD_RESERVATION_EVENT;
@@ -31,24 +39,56 @@ public class FoodEventListener {
   @Value("${foods.events.topics.release-fail}")
   private String FOOD_RELEASE_FAIL_EVENT;
 
-  // TODO apply @Async
+  @Async
   @TransactionalEventListener(phase = AFTER_COMMIT)
   public void on(FoodReservationProcessedEvent event) {
-    kafkaService.sendKafkaEvent(FOOD_RESERVATION_EVENT, event);
+    try {
+      kafkaService.sendKafkaEvent(FOOD_RESERVATION_EVENT, event);
+
+    } catch (Exception e) {
+      LogUtil.exception("FoodEventListener.on (FoodReservationProcessedEvent)", e);
+      foodService.release(event.getFoodId(), event.getQuantity());
+
+      eventPublisher.publishEvent(
+          EventToEventMapper.mapToCompensationEvent(event, ErrorCode.UNKNOWN_EXCEPTION));
+    }
   }
 
+  @Async
   @TransactionalEventListener(phase = AFTER_ROLLBACK)
   public void on(FoodReservationFailedEvent event) {
-    kafkaService.sendKafkaEvent(FOOD_RESERVATION_FAIL_EVENT, event);
+    try {
+      kafkaService.sendKafkaEvent(FOOD_RESERVATION_FAIL_EVENT, event);
+
+    } catch (Exception e) {
+      LogUtil.exception("FoodEventListener.on (FoodReservationFailedEvent)", e);
+      LogUtil.info("FoodEventListener.on (FoodReservationFailedEvent)", event);
+    }
   }
 
+  @Async
   @TransactionalEventListener(phase = AFTER_COMMIT)
   public void on(FoodReleaseEvent event) {
-    kafkaService.sendKafkaEvent(FOOD_RELEASE_EVENT, event);
+    try {
+      kafkaService.sendKafkaEvent(FOOD_RELEASE_EVENT, event);
+
+    } catch (Exception e) {
+      LogUtil.exception("FoodEventListener.on (FoodReleaseEvent)", e);
+
+      eventPublisher.publishEvent(
+          EventToEventMapper.mapToCompensationEvent(event, ErrorCode.FOOD_RELEASE_KAFKA_FAIL_EVENT));
+    }
   }
 
+  @Async
   @TransactionalEventListener(phase = AFTER_ROLLBACK)
   public void on(FoodReleaseFailedEvent event) {
-    kafkaService.sendKafkaEvent(FOOD_RELEASE_FAIL_EVENT, event);
+    try {
+      kafkaService.sendKafkaEvent(FOOD_RELEASE_FAIL_EVENT, event);
+
+    } catch (Exception e) {
+      LogUtil.exception("FoodEventListener.on (FoodReleaseFailedEvent)", e);
+      LogUtil.info("FoodEventListener.on (FoodReleaseFailedEvent)", event);
+    }
   }
 }

--- a/foods/src/main/java/com/f_lab/joyeuse_planete/foods/service/listener/FoodEventListener.java
+++ b/foods/src/main/java/com/f_lab/joyeuse_planete/foods/service/listener/FoodEventListener.java
@@ -62,7 +62,6 @@ public class FoodEventListener {
 
     } catch (Exception e) {
       LogUtil.exception("FoodEventListener.on (FoodReservationFailedEvent)", e);
-      LogUtil.info("FoodEventListener.on (FoodReservationFailedEvent)", event);
     }
   }
 
@@ -88,7 +87,6 @@ public class FoodEventListener {
 
     } catch (Exception e) {
       LogUtil.exception("FoodEventListener.on (FoodReleaseFailedEvent)", e);
-      LogUtil.info("FoodEventListener.on (FoodReleaseFailedEvent)", event);
     }
   }
 }

--- a/members/src/main/java/com/f_lab/joyeuse_planete/members/controller/MemberController.java
+++ b/members/src/main/java/com/f_lab/joyeuse_planete/members/controller/MemberController.java
@@ -9,6 +9,7 @@ import com.f_lab.joyeuse_planete.members.dto.request.SigninRequestDTO;
 import com.f_lab.joyeuse_planete.members.dto.request.SignupRequestDTO;
 import com.f_lab.joyeuse_planete.members.dto.response.SigninResponseDTO;
 import com.f_lab.joyeuse_planete.members.service.MemberService;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -63,7 +64,6 @@ public class MemberController {
     SigninResponseDTO signinResponseDTO = memberService.signin(request);
     cookieUtil.setRefreshTokenAsCookie(res, signinResponseDTO.getRefreshToken());
 
-
     return ResponseEntity
         .status(HttpStatus.CREATED)
         .body(signinResponseDTO);
@@ -72,9 +72,14 @@ public class MemberController {
 
   @PreAuthorize("hasRole('MEMBER') || hasRole('ADMIN')")
   @PostMapping("/signout/{memberId}")
-  public ResponseEntity<ResultResponse> signout(Authentication authentication) {
+  public ResponseEntity<ResultResponse> signout(
+      Authentication authentication,
+      HttpServletRequest req,
+      HttpServletResponse res
+  ) {
 
     memberService.signout((Long) authentication.getPrincipal());
+    cookieUtil.deleteCookie(req, res);
 
     return ResponseEntity
         .ok(ResultResponse.of(CommonResponses.DELETE_SUCCESS, HttpStatus.OK.value()));

--- a/orders/src/main/java/com/f_lab/joyeuse_planete/orders/config/AsyncConfig.java
+++ b/orders/src/main/java/com/f_lab/joyeuse_planete/orders/config/AsyncConfig.java
@@ -1,0 +1,15 @@
+package com.f_lab.joyeuse_planete.orders.config;
+
+
+import com.f_lab.joyeuse_planete.core.config.DefaultAsyncConfig;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AsyncConfig {
+
+  @Bean
+  public DefaultAsyncConfig defaultAsyncConfig() {
+    return new DefaultAsyncConfig();
+  }
+}

--- a/orders/src/main/java/com/f_lab/joyeuse_planete/orders/config/AsyncConfig.java
+++ b/orders/src/main/java/com/f_lab/joyeuse_planete/orders/config/AsyncConfig.java
@@ -2,14 +2,9 @@ package com.f_lab.joyeuse_planete.orders.config;
 
 
 import com.f_lab.joyeuse_planete.core.config.DefaultAsyncConfig;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-public class AsyncConfig {
+public class AsyncConfig extends DefaultAsyncConfig {
 
-  @Bean
-  public DefaultAsyncConfig defaultAsyncConfig() {
-    return new DefaultAsyncConfig();
-  }
 }

--- a/orders/src/main/java/com/f_lab/joyeuse_planete/orders/service/listener/OrderEventListener.java
+++ b/orders/src/main/java/com/f_lab/joyeuse_planete/orders/service/listener/OrderEventListener.java
@@ -1,11 +1,15 @@
 package com.f_lab.joyeuse_planete.orders.service.listener;
 
 
+import com.f_lab.joyeuse_planete.core.domain.OrderStatus;
 import com.f_lab.joyeuse_planete.core.events.OrderCancelEvent;
 import com.f_lab.joyeuse_planete.core.events.OrderCreatedEvent;
 import com.f_lab.joyeuse_planete.core.kafka.service.KafkaService;
+import com.f_lab.joyeuse_planete.core.util.log.LogUtil;
+import com.f_lab.joyeuse_planete.orders.service.OrderService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionalEventListener;
 
@@ -16,6 +20,7 @@ import static org.springframework.transaction.event.TransactionPhase.AFTER_COMMI
 public class OrderEventListener {
 
   private final KafkaService kafkaService;
+  private final OrderService orderService;
 
   @Value("${orders.events.topics.create}")
   String ORDER_CREATED_EVENT;
@@ -23,13 +28,25 @@ public class OrderEventListener {
   @Value("${orders.events.topics.cancel}")
   String ORDER_CANCELLATION_EVENT;
 
+  @Async
   @TransactionalEventListener(phase = AFTER_COMMIT)
   public void on(OrderCreatedEvent event) {
-    kafkaService.sendKafkaEvent(ORDER_CREATED_EVENT, event);
+    try {
+      kafkaService.sendKafkaEvent(ORDER_CREATED_EVENT, event);
+    } catch (Exception e) {
+      LogUtil.exception("OrderEventListener.on (OrderCreatedEvent)", e);
+      orderService.updateOrderStatus(event.getOrderId(), OrderStatus.FAIL_ORDER);
+    }
   }
 
+  @Async
   @TransactionalEventListener(phase = AFTER_COMMIT)
   public void on(OrderCancelEvent event) {
-    kafkaService.sendKafkaEvent(ORDER_CANCELLATION_EVENT, event);
+    try {
+      kafkaService.sendKafkaEvent(ORDER_CANCELLATION_EVENT, event);
+    } catch (Exception e) {
+      LogUtil.exception("OrderEventListener.on (OrderCancelEvent)", e);
+      orderService.updateOrderStatus(event.getOrderId(), OrderStatus.FAIL_CANCEL);
+    }
   }
 }

--- a/orders/src/test/java/com/f_lab/joyeuse_planete/orders/repository/OrderRepositoryTest.java
+++ b/orders/src/test/java/com/f_lab/joyeuse_planete/orders/repository/OrderRepositoryTest.java
@@ -232,7 +232,7 @@ class OrderRepositoryTest {
 
         Order.builder()
             .totalCost(BigDecimal.valueOf(3000.0))
-            .status(OrderStatus.FAIL)
+            .status(OrderStatus.FAIL_ORDER)
             .createdAt(LocalDateTime.of(2022, Month.JANUARY, 21, 10, 10, 10))
             .build(),
 
@@ -262,7 +262,7 @@ class OrderRepositoryTest {
 
         Order.builder()
             .totalCost(BigDecimal.valueOf(3000.0))
-            .status(OrderStatus.FAIL)
+            .status(OrderStatus.FAIL_ORDER)
             .createdAt(LocalDateTime.of(2018, Month.JANUARY, 21, 10, 10, 10))
             .build(),
 

--- a/orders/src/test/java/com/f_lab/joyeuse_planete/orders/repository/OrderRepositoryTest.java
+++ b/orders/src/test/java/com/f_lab/joyeuse_planete/orders/repository/OrderRepositoryTest.java
@@ -116,7 +116,7 @@ class OrderRepositoryTest {
   @DisplayName("주문 상태 조건을 변경하였을 때 작동하는 것을 확인")
   void testOrderStatusConditionSuccess() {
     // given
-    String status = "FAIL";
+    String status = "FAIL_ORDER";
     List<String> sortBy = List.of("DATE_NEW");
 
     OrderSearchCondition condition = createSearchCondition(null, null, status, null, null, sortBy, 0, 10);

--- a/payment/src/main/java/com/f_lab/joyeuse_planete/payment/config/AsyncConfig.java
+++ b/payment/src/main/java/com/f_lab/joyeuse_planete/payment/config/AsyncConfig.java
@@ -1,4 +1,4 @@
-package com.f_lab.joyeuse_planete.foods.config;
+package com.f_lab.joyeuse_planete.payment.config;
 
 import com.f_lab.joyeuse_planete.core.config.DefaultAsyncConfig;
 import org.springframework.context.annotation.Configuration;

--- a/payment/src/main/java/com/f_lab/joyeuse_planete/payment/service/listener/PaymentEventListener.java
+++ b/payment/src/main/java/com/f_lab/joyeuse_planete/payment/service/listener/PaymentEventListener.java
@@ -5,8 +5,10 @@ import com.f_lab.joyeuse_planete.core.events.PaymentProcessingFailedEvent;
 import com.f_lab.joyeuse_planete.core.events.RefundProcessedEvent;
 import com.f_lab.joyeuse_planete.core.events.RefundProcessingFailedEvent;
 import com.f_lab.joyeuse_planete.core.kafka.service.KafkaService;
+import com.f_lab.joyeuse_planete.core.util.log.LogUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionalEventListener;
 
@@ -30,23 +32,43 @@ public class PaymentEventListener {
   @Value("${payment.events.topics.refund-fail}")
   private String PAYMENT_REFUND_FAIL_EVENT;
 
+  @Async
   @TransactionalEventListener(phase = AFTER_COMMIT)
   public void on(PaymentProcessedEvent event) {
-    kafkaService.sendKafkaEvent(PAYMENT_PROCESS_EVENT, event);
+    try {
+      kafkaService.sendKafkaEvent(PAYMENT_PROCESS_EVENT, event);
+    } catch (Exception e) {
+      LogUtil.exception("PaymentEventListener.on (PaymentProcessedEvent)", e);
+    }
   }
 
+  @Async
   @TransactionalEventListener(phase = AFTER_COMMIT)
   public void on(PaymentProcessingFailedEvent event) {
-    kafkaService.sendKafkaEvent(PAYMENT_PROCESS_FAIL_EVENT, event);
+    try {
+      kafkaService.sendKafkaEvent(PAYMENT_PROCESS_FAIL_EVENT, event);
+    } catch (Exception e) {
+      LogUtil.exception("PaymentEventListener.on (PaymentProcessingFailedEvent)", e);
+    }
   }
 
+  @Async
   @TransactionalEventListener(phase = AFTER_COMMIT)
   public void on(RefundProcessedEvent event) {
-    kafkaService.sendKafkaEvent(PAYMENT_REFUND_PROCESSED_EVENT, event);
+    try {
+      kafkaService.sendKafkaEvent(PAYMENT_REFUND_PROCESSED_EVENT, event);
+    } catch (Exception e) {
+      LogUtil.exception("PaymentEventListener.on (RefundProcessedEvent)", e);
+    }
   }
 
+  @Async
   @TransactionalEventListener(phase = AFTER_COMMIT)
   public void on(RefundProcessingFailedEvent event) {
-    kafkaService.sendKafkaEvent(PAYMENT_REFUND_FAIL_EVENT, event);
+    try {
+      kafkaService.sendKafkaEvent(PAYMENT_REFUND_FAIL_EVENT, event);
+    } catch (Exception e) {
+      LogUtil.exception("PaymentEventListener.on (RefundProcessingFailedEvent)", e);
+    }
   }
 }

--- a/payment/src/main/java/com/f_lab/joyeuse_planete/payment/service/thirdparty/PaymentProviderConstants.java
+++ b/payment/src/main/java/com/f_lab/joyeuse_planete/payment/service/thirdparty/PaymentProviderConstants.java
@@ -1,0 +1,8 @@
+package com.f_lab.joyeuse_planete.payment.service.thirdparty;
+
+public abstract class PaymentProviderConstants {
+
+  public static final int PAYMENT_API_ATTEMPTS = 3;
+  public static final int PAYMENT_API_DELAYED_SECONDS = 3;
+  public static final double PAYMENT_API_DELAYED_MULTIPLIER = 0.75;
+}

--- a/payment/src/main/java/com/f_lab/joyeuse_planete/payment/service/thirdparty/exceptions/PaymentAPIRetryableException.java
+++ b/payment/src/main/java/com/f_lab/joyeuse_planete/payment/service/thirdparty/exceptions/PaymentAPIRetryableException.java
@@ -1,0 +1,4 @@
+package com.f_lab.joyeuse_planete.payment.service.thirdparty.exceptions;
+
+public class PaymentAPIRetryableException extends RuntimeException {
+}


### PR DESCRIPTION
- 로그아웃시 쿠키 삭제 로직을 구현하였습니다.
- 기존의 jwt 토큰이 memberId만을 생각하지 않고 store의 id도 저장하고 universal 하게 쓰기 위해서 메서드의 이름들과 인스턴스 변수들의 이름들을 id 로 변경하였습니다. 