### PR TITLE
feat: Applied async to payment project

### DIFF
--- a/core/src/main/java/com/f_lab/joyeuse_planete/core/config/DefaultAsyncConfig.java
+++ b/core/src/main/java/com/f_lab/joyeuse_planete/core/config/DefaultAsyncConfig.java
@@ -9,7 +9,7 @@ import java.util.concurrent.Executor;
 
 @EnableAsync
 @Configuration
-public class DefaultAsyncConfig {
+public abstract class DefaultAsyncConfig {
 
   private static final int CORE_POOL_SIZE = 20;
   private static final int MAX_POOL_SIZE = Integer.MAX_VALUE;
@@ -17,7 +17,7 @@ public class DefaultAsyncConfig {
   private static final String NAME_PREFIX = "ASYNC_THREAD_";
 
   @Bean(name = { "executor", "asyncExecutor" })
-  public Executor taskExecutor() {
+  protected Executor taskExecutor() {
     ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
 
     executor.setCorePoolSize(CORE_POOL_SIZE);

--- a/orders/src/main/java/com/f_lab/joyeuse_planete/orders/config/AsyncConfig.java
+++ b/orders/src/main/java/com/f_lab/joyeuse_planete/orders/config/AsyncConfig.java
@@ -2,14 +2,9 @@ package com.f_lab.joyeuse_planete.orders.config;
 
 
 import com.f_lab.joyeuse_planete.core.config.DefaultAsyncConfig;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-public class AsyncConfig {
+public class AsyncConfig extends DefaultAsyncConfig {
 
-  @Bean
-  public DefaultAsyncConfig defaultAsyncConfig() {
-    return new DefaultAsyncConfig();
-  }
 }

--- a/payment/src/main/java/com/f_lab/joyeuse_planete/payment/config/AsyncConfig.java
+++ b/payment/src/main/java/com/f_lab/joyeuse_planete/payment/config/AsyncConfig.java
@@ -1,4 +1,4 @@
-package com.f_lab.joyeuse_planete.foods.config;
+package com.f_lab.joyeuse_planete.payment.config;
 
 import com.f_lab.joyeuse_planete.core.config.DefaultAsyncConfig;
 import org.springframework.context.annotation.Configuration;

--- a/payment/src/main/java/com/f_lab/joyeuse_planete/payment/service/listener/PaymentEventListener.java
+++ b/payment/src/main/java/com/f_lab/joyeuse_planete/payment/service/listener/PaymentEventListener.java
@@ -5,8 +5,10 @@ import com.f_lab.joyeuse_planete.core.events.PaymentProcessingFailedEvent;
 import com.f_lab.joyeuse_planete.core.events.RefundProcessedEvent;
 import com.f_lab.joyeuse_planete.core.events.RefundProcessingFailedEvent;
 import com.f_lab.joyeuse_planete.core.kafka.service.KafkaService;
+import com.f_lab.joyeuse_planete.core.util.log.LogUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionalEventListener;
 
@@ -30,23 +32,43 @@ public class PaymentEventListener {
   @Value("${payment.events.topics.refund-fail}")
   private String PAYMENT_REFUND_FAIL_EVENT;
 
+  @Async
   @TransactionalEventListener(phase = AFTER_COMMIT)
   public void on(PaymentProcessedEvent event) {
-    kafkaService.sendKafkaEvent(PAYMENT_PROCESS_EVENT, event);
+    try {
+      kafkaService.sendKafkaEvent(PAYMENT_PROCESS_EVENT, event);
+    } catch (Exception e) {
+      LogUtil.exception("PaymentEventListener.on (PaymentProcessedEvent)", e);
+    }
   }
 
+  @Async
   @TransactionalEventListener(phase = AFTER_COMMIT)
   public void on(PaymentProcessingFailedEvent event) {
-    kafkaService.sendKafkaEvent(PAYMENT_PROCESS_FAIL_EVENT, event);
+    try {
+      kafkaService.sendKafkaEvent(PAYMENT_PROCESS_FAIL_EVENT, event);
+    } catch (Exception e) {
+      LogUtil.exception("PaymentEventListener.on (PaymentProcessingFailedEvent)", e);
+    }
   }
 
+  @Async
   @TransactionalEventListener(phase = AFTER_COMMIT)
   public void on(RefundProcessedEvent event) {
-    kafkaService.sendKafkaEvent(PAYMENT_REFUND_PROCESSED_EVENT, event);
+    try {
+      kafkaService.sendKafkaEvent(PAYMENT_REFUND_PROCESSED_EVENT, event);
+    } catch (Exception e) {
+      LogUtil.exception("PaymentEventListener.on (RefundProcessedEvent)", e);
+    }
   }
 
+  @Async
   @TransactionalEventListener(phase = AFTER_COMMIT)
   public void on(RefundProcessingFailedEvent event) {
-    kafkaService.sendKafkaEvent(PAYMENT_REFUND_FAIL_EVENT, event);
+    try {
+      kafkaService.sendKafkaEvent(PAYMENT_REFUND_FAIL_EVENT, event);
+    } catch (Exception e) {
+      LogUtil.exception("PaymentEventListener.on (RefundProcessingFailedEvent)", e);
+    }
   }
 }

--- a/payment/src/main/java/com/f_lab/joyeuse_planete/payment/service/thirdparty/PaymentProviderConstants.java
+++ b/payment/src/main/java/com/f_lab/joyeuse_planete/payment/service/thirdparty/PaymentProviderConstants.java
@@ -1,0 +1,8 @@
+package com.f_lab.joyeuse_planete.payment.service.thirdparty;
+
+public abstract class PaymentProviderConstants {
+
+  public static final int PAYMENT_API_ATTEMPTS = 3;
+  public static final int PAYMENT_API_DELAYED_SECONDS = 3;
+  public static final double PAYMENT_API_DELAYED_MULTIPLIER = 0.75;
+}

--- a/payment/src/main/java/com/f_lab/joyeuse_planete/payment/service/thirdparty/exceptions/PaymentAPIRetryableException.java
+++ b/payment/src/main/java/com/f_lab/joyeuse_planete/payment/service/thirdparty/exceptions/PaymentAPIRetryableException.java
@@ -1,0 +1,4 @@
+package com.f_lab.joyeuse_planete.payment.service.thirdparty.exceptions;
+
+public class PaymentAPIRetryableException extends RuntimeException {
+}


### PR DESCRIPTION
- payment 프로젝트에 비동기를 적용하였습니다.
  - 이벤트 리스너에 비동기를 적용했습니다.
  - 문제가 생긴다면 이미 수 많은 재시도 끝에 결제 관련 로직이 실행되었기 때문에 고객센터에 직접 해결 하는 것이 낫다고 판단해서 로그만 남겨두었습니다.
